### PR TITLE
fix(ci): Skip running brew update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Install OpenSSL (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          brew update
           brew install openssl
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> $GITHUB_ENV
 


### PR DESCRIPTION
# Description of change

Skips running `brew update` before installing, as Homebrew automatically runs `brew update --preinstall` (which is faster) before installing formulae.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code