### PR TITLE
fix(ci): Skip OpenSSL installation on macOS

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,12 +62,9 @@ jobs:
           cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
     # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on macOS
-    - name: Install OpenSSL (macOS)
+    - name: Set OpenSSL location (macOS)
       if: matrix.os == 'macos-latest'
-      run: |
-        brew update
-        brew install openssl
-        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> $GITHUB_ENV
+      run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
 
     # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on Windows
     - name: Install OpenSSL (Windows)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,12 +56,9 @@ jobs:
           profile: minimal
 
       # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on macOS
-      - name: Install OpenSSL (macOS)
+      - name: Set OpenSSL location (macOS)
         if: matrix.os == 'macos-latest'
-        run: |
-          brew update
-          brew install openssl
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> $GITHUB_ENV
+        run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
 
       # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on Windows
       - name: Install OpenSSL (Windows)


### PR DESCRIPTION
# Description of change

It looks like OpenSSL is already installed on the GitHub Actions macOS runners, so we can save time by skipping that step

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
