### PR TITLE
fix: Link OpenSSL statically

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build-and-test:
+    env:
+      OPENSSL_LINK_STATIC: true
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -66,12 +68,20 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
 
+    - name: Set OpenSSL location (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: echo "RUSTFLAGS=-L /usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
+
     # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on Windows
+    # Prebuilt OpenSSL 1.1.1g from https://github.com/microsoft/vcpkg/releases/tag/2020.11
     - name: Install OpenSSL (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        choco install openssl --no-progress
-        echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest https://iotaledger-files.s3.eu-central-1.amazonaws.com/prebuild/openssl/windows/vcpkg-export-openssl-1.1.1g.zip -OutFile openssl.zip
+        Expand-Archive openssl.zip
+        Remove-Item openssl.zip
+        echo "OPENSSL_ROOT_DIR=${{ github.workspace }}/openssl/installed/x64-windows-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Build
       uses: actions-rs/cargo@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,8 @@ jobs:
     needs: create-release
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      OPENSSL_LINK_STATIC: true
 
     strategy:
       fail-fast: false
@@ -60,17 +62,25 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
       
+      - name: Set OpenSSL location (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "RUSTFLAGS=-L /usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
+      
       - name: Install gon (macOS)
         # https://github.com/mitchellh/gon
         run: brew install mitchellh/gon/gon
         if: matrix.os == 'macos-latest'
 
       # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on Windows
+      # Prebuilt OpenSSL 1.1.1g from https://github.com/microsoft/vcpkg/releases/tag/2020.11
       - name: Install OpenSSL (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          choco install openssl --no-progress
-          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest https://iotaledger-files.s3.eu-central-1.amazonaws.com/prebuild/openssl/windows/vcpkg-export-openssl-1.1.1g.zip -OutFile openssl.zip
+          Expand-Archive openssl.zip
+          Remove-Item openssl.zip
+          echo "OPENSSL_ROOT_DIR=${{ github.workspace }}/openssl/installed/x64-windows-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # build the CLI
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,8 +1552,7 @@ checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 [[package]]
 name = "paho-mqtt"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b379c2be1a97027ccf7771de5d3953b75b52e74dd7caf915b3d642654606a285"
+source = "git+https://github.com/rajivshah3/paho.mqtt.rust?branch=feature/openssl-static-link-master#93967713e359eef78f3f5c6d14ddd2ae6a9039b4"
 dependencies = [
  "futures 0.3.8",
  "futures-timer",
@@ -1566,8 +1565,7 @@ dependencies = [
 [[package]]
 name = "paho-mqtt-sys"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0fd01a23b90ebbd5c53d483eeed0012f1c3e069c99977bf77e4194f72b648c"
+source = "git+https://github.com/rajivshah3/paho.mqtt.rust?branch=feature/openssl-static-link-master#93967713e359eef78f3f5c6d14ddd2ae6a9039b4"
 dependencies = [
  "cmake",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ futures = "0.3"
 [profile.release]
 lto = true
 codegen-units = 1
+
+[patch.crates-io]
+paho-mqtt = { git = "https://github.com/rajivshah3/paho.mqtt.rust", branch = "feature/openssl-static-link-master"}


### PR DESCRIPTION
# Description of change

Uses static linking for OpenSSL so that users do not need to install it themselves

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested macOS and Windows, have not tested Linux

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
