### PR TITLE
feat(cli): add dotenv support for saving/loading mnemonic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /wallet-cli-database
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "ed25519"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2595,7 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "dotenv",
  "futures 0.3.8",
  "iota-core",
  "iota-wallet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.4"
 serde_json = "1.0"
 futures = "0.3"
 tiny-bip39 = "0.7"
+dotenv = "0.15"
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,7 @@ fn new_account_command(
                 {
                     if flag {
                         let mut file = OpenOptions::new().append(true).create(true).open(".env")?;
-                        file.write_all(
-                            format!(r#"IOTA_WALLET_MNEMONIC="{}""#, mnemonic.phrase()).as_bytes(),
-                        )?;
+                        writeln!(file, r#"IOTA_WALLET_MNEMONIC="{}""#, mnemonic.phrase())?;
                         println!(
                             "mnemonic added to {:?}",
                             std::env::current_dir()?.join(".env")

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 
 use clap::{load_yaml, App, AppSettings, ArgMatches};
 use console::Term;
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, Confirm, Select};
+use dotenv::dotenv;
 use iota_wallet::{
     account::Account, account_manager::AccountManager, client::ClientOptionsBuilder,
     signing::SignerType, storage::sqlite::SqliteStorageAdapter, Result, WalletError,
@@ -11,7 +12,7 @@ use iota_wallet::{
 use once_cell::sync::OnceCell;
 use tokio::runtime::Runtime;
 
-use std::{env::var_os, sync::Mutex};
+use std::{env::var_os, fs::OpenOptions, io::Write, sync::Mutex};
 
 mod account;
 
@@ -94,6 +95,21 @@ fn new_account_command(
                 let mnemonic =
                     bip39::Mnemonic::new(bip39::MnemonicType::Words24, bip39::Language::English);
                 println!("Your mnemonic is `{:?}`, you must store it on an environment variable called `IOTA_WALLET_MNEMONIC` to use this CLI", mnemonic.phrase());
+                if let Ok(flag) = Confirm::new()
+                    .with_prompt("Do you want to store the mnemonic in a .env file?")
+                    .interact()
+                {
+                    if flag {
+                        let mut file = OpenOptions::new().append(true).create(true).open(".env")?;
+                        file.write_all(
+                            format!(r#"IOTA_WALLET_MNEMONIC="{}""#, mnemonic.phrase()).as_bytes(),
+                        )?;
+                        println!(
+                            "mnemonic added to {:?}",
+                            std::env::current_dir()?.join(".env")
+                        );
+                    }
+                }
                 builder = builder.mnemonic(mnemonic.into_phrase());
             }
         }
@@ -152,7 +168,7 @@ fn run() -> Result<()> {
     let storage_path = var_os("WALLET_DATABASE_PATH")
         .map(|os_str| os_str.into_string().expect("invalid WALLET_DATABASE_PATH"))
         .unwrap_or_else(|| "./wallet-cli-database".to_string());
-    let mut manager = AccountManager::with_storage_adapter(
+    let manager = AccountManager::with_storage_adapter(
         &storage_path,
         SqliteStorageAdapter::new(&storage_path, "accounts")?,
     )?;
@@ -190,6 +206,9 @@ fn run() -> Result<()> {
 }
 
 fn main() {
+    if let Ok(p) = dotenv() {
+        println!("loaded dotenv from {:?}", p);
+    }
     if let Err(e) = run() {
         print_error(e);
     }


### PR DESCRIPTION
# Description of change

Loads environment variables from a `.env` file and optionally stores the mnemonic on `${cwd}/.env`. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Creating an account.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
