### PR TITLE
feat(cli): add `--type` option to account creation (ledger nano support)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,6 +27,12 @@ jobs:
         toolchain: stable
         override: true
 
+    - name: Install required packages (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libudev-dev libusb-1.0-0-dev
+
     - name: Get current date
       run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,12 @@ jobs:
           toolchain: stable
           profile: minimal
 
+      - name: Install required packages (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
+
       # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on macOS
       - name: Set OpenSSL location (macOS)
         if: matrix.os == 'macos-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,7 +2908,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wallet-cli"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap 3.0.0-beta.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "syn 1.0.58",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,9 +126,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -132,7 +153,7 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 [[package]]
 name = "bee-common"
 version = "0.3.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#2f56d9dd7c601f7581e93b8d3e7259dd46e17740"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#8cdfe505e3e5a699655d2c43c4305fb109ec8c87"
 dependencies = [
  "autocfg",
  "chrono",
@@ -145,7 +166,7 @@ dependencies = [
 [[package]]
 name = "bee-common-derive"
 version = "0.1.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#2f56d9dd7c601f7581e93b8d3e7259dd46e17740"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#8cdfe505e3e5a699655d2c43c4305fb109ec8c87"
 dependencies = [
  "quote 1.0.8",
  "syn 1.0.58",
@@ -154,7 +175,7 @@ dependencies = [
 [[package]]
 name = "bee-crypto"
 version = "0.2.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#2f56d9dd7c601f7581e93b8d3e7259dd46e17740"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#8cdfe505e3e5a699655d2c43c4305fb109ec8c87"
 dependencies = [
  "bee-ternary",
  "byteorder",
@@ -166,7 +187,7 @@ dependencies = [
 [[package]]
 name = "bee-message"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#7d1520eaf47abdb8fee70f5629728a4c31479674"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#031825578dcff3e7a739fe4bb34af56b024bcc79"
 dependencies = [
  "bech32",
  "bee-common",
@@ -183,7 +204,7 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#7d1520eaf47abdb8fee70f5629728a4c31479674"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#031825578dcff3e7a739fe4bb34af56b024bcc79"
 dependencies = [
  "bee-crypto",
  "bee-ternary",
@@ -194,12 +215,12 @@ dependencies = [
 [[package]]
 name = "bee-signing"
 version = "0.1.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#2f56d9dd7c601f7581e93b8d3e7259dd46e17740"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#8cdfe505e3e5a699655d2c43c4305fb109ec8c87"
 dependencies = [
  "bee-common-derive",
  "bee-crypto",
  "bee-ternary",
- "rand 0.7.3",
+ "rand 0.8.2",
  "sha3",
  "thiserror",
  "zeroize 1.2.0",
@@ -225,7 +246,7 @@ dependencies = [
 [[package]]
 name = "bee-ternary"
 version = "0.4.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#2f56d9dd7c601f7581e93b8d3e7259dd46e17740"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#8cdfe505e3e5a699655d2c43c4305fb109ec8c87"
 dependencies = [
  "autocfg",
  "num-traits 0.2.14",
@@ -724,6 +745,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "syn 1.0.58",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1091,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "hidapi"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c352a18370f7e7e47bcbfcbdc5432b8c80c705b5d751a25232c659fcf5c775"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "hmac"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#07bad0b77e61b23fd1e3df3fd4f476ba3377c573"
+source = "git+https://github.com/iotaledger/iota.rs?branch=dev#f1f5a4d73c5a6444fc6e896525917fdbba147afa"
 dependencies = [
  "bee-common",
  "bee-crypto",
@@ -1207,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "0.2.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#07bad0b77e61b23fd1e3df3fd4f476ba3377c573"
+source = "git+https://github.com/iotaledger/iota.rs?branch=dev#f1f5a4d73c5a6444fc6e896525917fdbba147afa"
 dependencies = [
  "bee-common",
  "bee-message",
@@ -1274,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/wallet.rs?branch=develop#abeec31484bf78aae60ee37b00a5906ec1aecd68"
+source = "git+https://github.com/iotaledger/wallet.rs?branch=develop#b89a9ea11aeb8230193cc3793305da130121efa2"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1286,6 +1338,7 @@ dependencies = [
  "iota-core",
  "iota-crypto 0.2.0 (git+https://github.com/iotaledger/crypto.rs?rev=c2514969c3f6693b86425ec84bada84b3ebea645)",
  "iota-stronghold",
+ "ledger-iota",
  "log",
  "once_cell",
  "rand 0.7.3",
@@ -1341,6 +1394,77 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "ledger-apdu"
+version = "0.7.0"
+source = "git+https://gitlab.com/ledger-iota-chrysalis/ledger-rs#98354fc888209ac397a145008a1491d8eb8d5dac"
+
+[[package]]
+name = "ledger-iota"
+version = "0.1.0"
+source = "git+https://gitlab.com/ledger-iota-chrysalis/ledger-iota.rs#4b83def4554f667748bf40c5a209e4f9d64f93b6"
+dependencies = [
+ "bech32",
+ "enum-iterator",
+ "futures 0.3.12",
+ "ledger-apdu",
+ "ledger-transport",
+ "ledger-transport-hid",
+ "ledger-transport-tcp",
+ "log",
+ "serde 1.0.120",
+ "thiserror",
+ "trait-async",
+]
+
+[[package]]
+name = "ledger-transport"
+version = "0.7.0"
+source = "git+https://gitlab.com/ledger-iota-chrysalis/ledger-rs#98354fc888209ac397a145008a1491d8eb8d5dac"
+dependencies = [
+ "byteorder",
+ "futures 0.3.12",
+ "js-sys",
+ "lazy_static",
+ "ledger-apdu",
+ "ledger-transport-hid",
+ "ledger-transport-tcp",
+ "serde 1.0.120",
+ "thiserror",
+ "trait-async",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "ledger-transport-hid"
+version = "0.7.0"
+source = "git+https://gitlab.com/ledger-iota-chrysalis/ledger-rs#98354fc888209ac397a145008a1491d8eb8d5dac"
+dependencies = [
+ "byteorder",
+ "cfg-if 0.1.10",
+ "hex",
+ "hidapi",
+ "lazy_static",
+ "ledger-apdu",
+ "libc",
+ "log",
+ "nix",
+ "thiserror",
+]
+
+[[package]]
+name = "ledger-transport-tcp"
+version = "0.0.1"
+source = "git+https://gitlab.com/ledger-iota-chrysalis/ledger-rs#98354fc888209ac397a145008a1491d8eb8d5dac"
+dependencies = [
+ "hex",
+ "ledger-apdu",
+ "log",
+ "serde 1.0.120",
+ "thiserror",
+]
 
 [[package]]
 name = "lexical-core"
@@ -1467,6 +1591,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
@@ -1716,6 +1853,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "poly1305"
@@ -2573,10 +2716,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae4751faa60b9f96dd8344d74592e5a17c0c9a220413dbc6942d14139bbfcc"
+checksum = "feb971a26599ffd28066d387f109746df178eff14d5ea1e235015c5601967a4b"
 dependencies = [
+ "async-stream",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -2629,6 +2773,17 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "pin-project 0.4.27",
  "tracing",
+]
+
+[[package]]
+name = "trait-async"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe8c654712ee594c93b7222d98b4e61c7e003aec49e73877edac607a213699d"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -2744,6 +2899,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wallet-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", branch = "develop" }
+iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", branch = "develop", features = ["ledger-nano", "ledger-nano-simulator"] }
 iota-core = { git = "https://github.com/iotaledger/iota.rs", branch = "dev" }
 tokio = { version = "1.0", features = ["full"] }
 dialoguer = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-cli"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Lucas Nogueira <lucas.nogueira@iota.org>"]
 edition = "2018"
 homepage = "https://iota.org"

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Prints the CLI help information. If a command is specified, the command's help w
 
 #### mnemonic [MNEMONIC]
 
-Sets the mnemonic to use.
+Sets the 24 word mnemonic to use.
 
-#### new --node "http://node.url:portNumber" [--alias ALIAS --mnemonic 24_WORD_MNEMONIC_PHRASE]
+#### new [--node "http://node.url:portNumber" --alias ALIAS --type TYPE]
 
-Creates a new account connecting to the specified node URL. Optionally takes the account alias and 24 word mnemonic phrase.
+Creates a new account connecting to the default testnet node. Optionally takes the account alias, account type (one of `stronghold`, `ledger-nano` or `ledger-nano-simulator`) and a custom node URL.
 
 #### account ALIAS
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -26,7 +26,6 @@ subcommands:
             short: n
             long: node
             about: A node to connect to.
-            required: true
             takes_value: true
             multiple: true
         - pow:
@@ -40,6 +39,12 @@ subcommands:
             long: alias
             about: The account alias.
             takes_value: true
+        - type:
+            short: t
+            long: type
+            about: Account type.
+            takes_value: true
+            possible_values: [stronghold, ledger-nano, ledger-nano-simulator]
   - delete:
       about: Deletes an account.
       args:


### PR DESCRIPTION
# Description of change

Adds support to Ledger Nano accounts.

Usage:

`$ ./wallet new --type ledger-nano` - connects with a Ledger Nano S
`$ ./wallet new --type ledger-nano-simulator` - connects with [Speculos](https://github.com/LedgerHQ/speculos).

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the above examples and syncing, generating addresses and transfers.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
