### PR TITLE
fix(ci): Use Cargo.lock for cache keys and fix restore-keys

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,28 +46,30 @@ jobs:
       with:
         path: ~/.cargo/registry
         # Add date to the cache to keep it up to date
-        key: ${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
+        key: ${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}-${{ env.CURRENT_DATE }}
         # Restore from outdated cache for speed
         restore-keys: |
-          cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          ${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Cache cargo index
       uses: actions/cache@v2
       with:
         path: ~/.cargo/git
         # Add date to the cache to keep it up to date
-        key: ${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
+        key: ${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ env.CURRENT_DATE }}
         # Restore from outdated cache for speed
         restore-keys: |
-          cargo-index-${{ hashFiles('**/Cargo.toml') }}
+          ${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Cache cargo target
       uses: actions/cache@v2
       with:
         path: target
         # Add date to the cache to keep it up to date
-        key: ${{ matrix.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
+        key: ${{ matrix.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}-${{ env.CURRENT_DATE }}
         # Restore from outdated cache for speed
         restore-keys: |
-          cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+          ${{ matrix.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
     # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on macOS
     - name: Set OpenSSL location (macOS)


### PR DESCRIPTION
# Description of change

- Uses `Cargo.lock` for the cache keys since it's available
- Fixes `restore-keys` so that they match the generated cache key properly

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Crossing fingers and hoping the workflow succeeds 🤞 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code