### PR TITLE
fix(ci): Use actions/cache v2.1.4 on workflows that run on macOS

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
       run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Cache cargo registry
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       with:
         path: ~/.cargo/registry
         # Add date to the cache to keep it up to date
@@ -52,7 +52,7 @@ jobs:
           ${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo index
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       with:
         path: ~/.cargo/git
         # Add date to the cache to keep it up to date
@@ -62,7 +62,7 @@ jobs:
           ${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo target
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       with:
         path: target
         # Add date to the cache to keep it up to date


### PR DESCRIPTION
# Description of change

There's a known issue on GitHub Actions macOS runners when you cache the Rust `target` folder, specifically with `serde_derive` (https://github.com/actions/cache/issues/403). There seems to be something wrong with BSD `tar` so the Actions team included GNU `tar` with the new macOS image that was recently rolled out.  `actions/cache@v2.1.4` will use GNU tar if installed. This currently isn't released under the v2 tag as some people ran into permissions issues (https://github.com/actions/cache/issues/527), so we can pin it to this version for now.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Workflow runs successfully

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code