### PR TITLE
README: fix git clone path

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,6 @@ $ ./wallet [COMMAND] [OPTIONS]
 To run the CLI from source, install Rust (usually through [Rustup](https://rustup.rs/)) and run the following commands:
 
 ```
-$ git clone https://github.com/iotaledger/wallet.cli
+$ git clone https://github.com/iotaledger/cli-wallet
 $ cargo run -- [COMMAND] [OPTIONS]
 ```


### PR DESCRIPTION
# Description of change

Changed the link in the readme from `https://github.com/iotaledger/wallet.cli` to `https://github.com/iotaledger/cli-wallet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
