### PR TITLE
Fix default faucet address

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Gets the account balance.
 
 #### faucet [URL]
 
-Request funds from the faucet to the latest address, `url` is optional, default is `http://localhost:14265/api/plugins/faucet/v1/enqueue`.
+Request funds from the faucet to the latest address, `url` is optional, default is `http://localhost:8091/api/enqueue`.
 
 #### list-addresses
 

--- a/documentation/docs/03_account.md
+++ b/documentation/docs/03_account.md
@@ -77,19 +77,19 @@ Requests funds from a faucet.
 
 | Name      | Optional  | Default                                                 | Example                                                           |
 | --------- | --------- | ------------------------------------------------------- | ----------------------------------------------------------------- |
-| `url`     | ✓         | "http://localhost:14265/api/plugins/faucet/v1/enqueue"  | "http://localhost:14265/api/plugins/faucet/v1/enqueue"            |
+| `url`     | ✓         | "http://localhost:8091/api/enqueue"  | "http://localhost:8091/api/enqueue"            |
 | `address` | ✓         | The latest address of the account                       | "rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3" |
 
 #### Examples
 
 Request funds from a given faucet to the latest account address.
 ```sh
-> Account "main": faucet http://localhost:14265/api/plugins/faucet/v1/enqueue
+> Account "main": faucet http://localhost:8091/api/enqueue
 ```
 
 Request funds from a given faucet to a given address.
 ```sh
-> Account "main": faucet http://localhost:14265/api/plugins/faucet/v1/enqueue rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3
+> Account "main": faucet http://localhost:8091/api/enqueue rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3
 ```
 
 ### `help`

--- a/documentation/docs/03_account.md
+++ b/documentation/docs/03_account.md
@@ -75,10 +75,10 @@ Requests funds from a faucet.
 
 #### Parameters
 
-| Name      | Optional  | Default                                                 | Example                                                           |
-| --------- | --------- | ------------------------------------------------------- | ----------------------------------------------------------------- |
-| `url`     | ✓         | "http://localhost:8091/api/enqueue"  | "http://localhost:8091/api/enqueue"            |
-| `address` | ✓         | The latest address of the account                       | "rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3" |
+| Name      | Optional  | Default                              | Example                                                           |
+| --------- | --------- | ------------------------------------ | ----------------------------------------------------------------- |
+| `url`     | ✓         | "http://localhost:8091/api/enqueue"  | "http://localhost:8091/api/enqueue"                               |
+| `address` | ✓         | The latest address of the account    | "rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3" |
 
 #### Examples
 

--- a/src/command/account.rs
+++ b/src/command/account.rs
@@ -39,7 +39,7 @@ pub enum AccountCommand {
     Consolidate,
     /// Exit from the account prompt.
     Exit,
-    /// Request funds from the faucet to the latest address, `url` is optional, default is `http://localhost:14265/api/plugins/faucet/v1/enqueue`
+    /// Request funds from the faucet to the latest address, `url` is optional, default is `http://localhost:8091/api/enqueue`
     Faucet {
         url: Option<String>,
         address: Option<String>,
@@ -144,7 +144,7 @@ pub async fn faucet_command(
     };
     let faucet_url = match &url {
         Some(faucet_url) => faucet_url,
-        None => "http://localhost:14265/api/plugins/faucet/v1/enqueue",
+        None => "http://localhost:8091/api/enqueue",
     };
 
     log::info!("{}", request_funds_from_faucet(faucet_url, &address).await?);


### PR DESCRIPTION
# Description of change

Changed the default faucet endpoint as it isn't registered as an hornet endpoint

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on local private tangle. Now it works without specifying a node

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
