### PR TITLE
Use interact() instead of interact_text() to not fail for special characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "cli-wallet"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "clap",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-wallet"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 homepage = "https://iota.org"

--- a/src/account.rs
+++ b/src/account.rs
@@ -33,7 +33,7 @@ pub async fn account_prompt_internal(account_handle: AccountHandle) -> Result<bo
     };
     let command: String = Input::new()
         .with_prompt(format!("Account \"{}\"", alias))
-        .interact_text()?;
+        .interact()?;
 
     match command.as_str() {
         "h" => {


### PR DESCRIPTION
# Description of change

Special characters (non ascii) currently break the cli. This PR fixes that.