### PR TITLE
Add create-alias-output and more features to mint-nft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "2.0.0-beta.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=6b7004fb130fa5765539c9bea707d92c3eb1ff72#6b7004fb130fa5765539c9bea707d92c3eb1ff72"
+source = "git+https://github.com/iotaledger/iota.rs?rev=d83b75ca52c4444220df496e725d3753cf0b7fe3#d83b75ca52c4444220df496e725d3753cf0b7fe3"
 dependencies = [
  "async-trait",
  "backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "iota-client"
-version = "2.0.0"
+version = "2.0.1-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ae94587047347f002c1ced9dfcc2a423ab3255fc16c8dba9a1c9bc515290f8"
+checksum = "c8dd378840fa78c8927d83b18a689f8755f0458d9a8019dbc731f5eb85c88c1e"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1251,7 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "iota-wallet"
-version = "0.2.0"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afafb59084b922878889178eea01bb6445a1f51c13933f7143eb32f4357a880"
 dependencies = [
  "async-trait",
  "backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bee-api-types"
-version = "1.0.0-beta.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee8f42eece01082cb68ac6b56395799a4d1cf59efe223000fabd0aa2da3e612"
+checksum = "539b26b6963b744909bfa6d130a85d2abc0f45a9aaad2400633100604521422b"
 dependencies = [
  "bee-block",
  "bee-ledger-types",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "bee-block"
-version = "1.0.0-beta.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71668eae085ca48a59582e1c63a0d245b70c9fdbddd8fb31b37f1eb15a42bff5"
+checksum = "7d124ffdd80872942bb979a0b2b21e9fe069b5eca6c38997e33de30749b94261"
 dependencies = [
  "bech32",
  "bee-pow",
@@ -162,7 +162,7 @@ dependencies = [
  "derive_more",
  "hashbrown",
  "hex",
- "iota-crypto 0.14.2",
+ "iota-crypto 0.14.3",
  "iterator-sorted",
  "packable",
  "prefix-hex",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "bee-ledger-types"
-version = "1.0.0-beta.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda485ea7a4c023f99b485288bb2c7f79bbbf24de4940ff80be2ab6504a9462"
+checksum = "8bb8f7b8c5bf371243e6fe36c6feb0985a84ff15ca6251b60749be490d2fd05a"
 dependencies = [
  "bee-block",
  "packable",
@@ -186,20 +186,20 @@ dependencies = [
 
 [[package]]
 name = "bee-pow"
-version = "1.0.0-beta.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97ca064b7895679b723b1e188bad6103adad5cd712168185fb73fbfe6c205f0"
+checksum = "740c63e550d741613893a432c03db714bc1d6ff85882b88ded0f0920c06e98a6"
 dependencies = [
  "bee-ternary",
- "iota-crypto 0.14.2",
+ "iota-crypto 0.14.3",
  "thiserror",
 ]
 
 [[package]]
 name = "bee-ternary"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9252b65ddd9a863b0efc06ddab6c26334ecbe00fb8fa47bbde10babda2981b2"
+checksum = "303a046c924e0b635640033126ca5d87c1e905b070f8c3251478fb606acb55b3"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1162,8 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "iota-client"
-version = "2.0.0-beta.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=d83b75ca52c4444220df496e725d3753cf0b7fe3#d83b75ca52c4444220df496e725d3753cf0b7fe3"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ae94587047347f002c1ced9dfcc2a423ab3255fc16c8dba9a1c9bc515290f8"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1175,7 +1176,7 @@ dependencies = [
  "futures",
  "gloo-timers",
  "instant",
- "iota-crypto 0.14.2",
+ "iota-crypto 0.14.3",
  "iota_stronghold",
  "log",
  "num_cpus",
@@ -1228,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "iota-crypto"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d67b0725fbfe9e75950848bf0304df70ecb71a58526b1a36a087d0bc089499"
+checksum = "d53239ace29cccec48af2f3b509090d546bcc52648c6147866d88bc70f4352b3"
 dependencies = [
  "aead",
  "bee-ternary",
@@ -1257,7 +1258,7 @@ dependencies = [
  "futures",
  "getset",
  "iota-client",
- "iota-crypto 0.14.2",
+ "iota-crypto 0.14.3",
  "log",
  "packable",
  "prefix-hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "2.0.0-beta.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=d83b75ca52c4444220df496e725d3753cf0b7fe3#d83b75ca52c4444220df496e725d3753cf0b7fe3"
+source = "git+https://github.com/iotaledger/iota.rs?rev=6b7004fb130fa5765539c9bea707d92c3eb1ff72#6b7004fb130fa5765539c9bea707d92c3eb1ff72"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1251,7 +1251,6 @@ dependencies = [
 [[package]]
 name = "iota-wallet"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/wallet.rs?rev=a45278f2c06058a24bd056a9f91f08d3e42fa9fa#a45278f2c06058a24bd056a9f91f08d3e42fa9fa"
 dependencies = [
  "async-trait",
  "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ path = "src/main.rs"
 clap = { version = "3.2.8", default-features = false, features = [ "derive", "std" ] }
 dialoguer = { version = "0.10.1", default-features = false, features = [ "password" ] }
 fern-logger = { version = "0.5.0", default-features = false }
-# iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "a45278f2c06058a24bd056a9f91f08d3e42fa9fa", default-features = false, features = [ "storage", "stronghold" ] }
-iota-wallet = { path = "../wallet.rs", default-features = false, features = [ "storage", "stronghold" ] }
+iota-wallet = { version = "1.0.0-rc.1", default-features = false, features = [ "storage", "stronghold" ] }
 log = { version = "0.4.17", default-features = false }
 prefix-hex = { version = "0.4.0", default-features = false, features = [ "std" ] }
 serde_json = { version = "1.0.85", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ path = "src/main.rs"
 clap = { version = "3.2.8", default-features = false, features = [ "derive", "std" ] }
 dialoguer = { version = "0.10.1", default-features = false, features = [ "password" ] }
 fern-logger = { version = "0.5.0", default-features = false }
-iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "a45278f2c06058a24bd056a9f91f08d3e42fa9fa", default-features = false, features = [ "storage", "stronghold" ] }
+# iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", rev = "a45278f2c06058a24bd056a9f91f08d3e42fa9fa", default-features = false, features = [ "storage", "stronghold" ] }
+iota-wallet = { path = "../wallet.rs", default-features = false, features = [ "storage", "stronghold" ] }
 log = { version = "0.4.17", default-features = false }
 prefix-hex = { version = "0.4.0", default-features = false, features = [ "std" ] }
 serde_json = { version = "1.0.85", default-features = false }

--- a/documentation/docs/03_account.md
+++ b/documentation/docs/03_account.md
@@ -106,6 +106,16 @@ Note that only Basic Outputs with only an address unlock condition can be consol
 > Account "main": consolidate
 ```
 
+### `create-alias-output`
+
+Create a new alias output.
+
+#### Example
+
+```sh
+> Account "main": create-alias-output
+```
+
 ### `decrease-native-token-supply`
 
 Melts a native token.
@@ -260,6 +270,9 @@ Mints an NFT.
 | `immutable_metadata_file` | ✓         | None                              | metadata.json                                                   |
 | `metadata_hex`            | ✓         | None                              | 0xabcdef                                                        |
 | `metadata_file`           | ✓         | None                              | metadata.json                                                   |
+| `tag`                     | ✓         | None                              | 0xabcdef                                                        |
+| `sender`                  | ✓         | None                              | rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3 |
+| `issuer`                  | ✓         | None                              | rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3 |
 
 #### Examples
 
@@ -276,6 +289,11 @@ Mint an NFT to a given address.
 Mint an NFT to a given address with hexadecimal immutable metadata and metadata from a file.
 ```sh
 > Account "main": mint-nft rms1qztwng6cty8cfm42nzvq099ev7udhrnk0rw8jt8vttf9kpqnxhpsx869vr3 --immutable-metadata-hex 0xabcdef --metadata-file metadata.json
+```
+
+Mint an NFT to a given address with hexadecimal tag and sender feature.
+```sh
+> Account "main": mint-nft --tag 0xabcdef --sender rms1qq5k0ut6nl2vpyehdvg5k4ygyntd4r44t9lw2ksex280x60lc2fmcgdsmku
 ```
 
 ### `new-address`

--- a/src/account.rs
+++ b/src/account.rs
@@ -8,9 +8,9 @@ use iota_wallet::account::AccountHandle;
 use crate::{
     command::account::{
         addresses_command, balance_command, burn_native_token_command, burn_nft_command, claim_command,
-        consolidate_command, decrease_native_token_command, destroy_alias_command, destroy_foundry_command,
-        faucet_command, increase_native_token_command, mint_native_token_command, mint_nft_command,
-        new_address_command, output_command, outputs_command, send_command, send_micro_command,
+        consolidate_command, create_alias_outputs_command, decrease_native_token_command, destroy_alias_command,
+        destroy_foundry_command, faucet_command, increase_native_token_command, mint_native_token_command,
+        mint_nft_command, new_address_command, output_command, outputs_command, send_command, send_micro_command,
         send_native_token_command, send_nft_command, sync_command, transactions_command, unspent_outputs_command,
         AccountCli, AccountCommand,
     },
@@ -70,6 +70,7 @@ pub async fn account_prompt_internal(account_handle: AccountHandle) -> Result<bo
                 AccountCommand::BurnNft { nft_id } => burn_nft_command(&account_handle, nft_id).await,
                 AccountCommand::Claim { output_id } => claim_command(&account_handle, output_id).await,
                 AccountCommand::Consolidate => consolidate_command(&account_handle).await,
+                AccountCommand::CreateAliasOutput => create_alias_outputs_command(&account_handle).await,
                 AccountCommand::DecreaseNativeTokenSupply { token_id, amount } => {
                     decrease_native_token_command(&account_handle, token_id, amount).await
                 }
@@ -104,12 +105,18 @@ pub async fn account_prompt_internal(account_handle: AccountHandle) -> Result<bo
                     immutable_metadata_file,
                     metadata_hex,
                     metadata_file,
+                    tag,
+                    sender,
+                    issuer,
                 } => {
                     mint_nft_command(
                         &account_handle,
                         address,
                         bytes_from_hex_or_file(immutable_metadata_hex, immutable_metadata_file).await?,
                         bytes_from_hex_or_file(metadata_hex, metadata_file).await?,
+                        tag,
+                        sender,
+                        issuer,
                     )
                     .await
                 }


### PR DESCRIPTION
# Description of change

Add `create-alias-output` since that's not done automatically anymore in `mint-native-token` and more features to `mint-nft`

## Links to any relevant issues

Related to https://github.com/iotaledger/cli-wallet/issues/153

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the commands

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
