### PR TITLE
Remove $ from code block so that the copy feature can be used

### DIFF
--- a/documentation/docs/01_installation.md
+++ b/documentation/docs/01_installation.md
@@ -14,7 +14,7 @@ Compare the checksum from the release with a checksum locally produced.
 
 You can use the following command to produce the checksum.
 ```sh
-$ shasum -a 256 [PATH TO BINARY]
+shasum -a 256 [PATH TO BINARY]
 ```
 
 ### 3. Rename
@@ -22,7 +22,7 @@ $ shasum -a 256 [PATH TO BINARY]
 For convenience, rename the binary to simply `wallet`.
 
 ```sh
-$ mv [PATH TO BINARY] wallet
+mv [PATH TO BINARY] wallet
 ```
 
 ## From source
@@ -34,9 +34,9 @@ https://www.rust-lang.org/tools/install
 ### 2. Compile
 
 ```sh
-$ git clone git@github.com:iotaledger/cli-wallet.git -b develop
-$ cd cli-wallet
-$ cargo build --profile production
+git clone git@github.com:iotaledger/cli-wallet.git -b develop
+cd cli-wallet
+cargo build --profile production
 ```
 
 Resulting binary will be located at `./target/production/wallet`.

--- a/documentation/docs/01_installation.md
+++ b/documentation/docs/01_installation.md
@@ -34,7 +34,7 @@ https://www.rust-lang.org/tools/install
 ### 2. Compile
 
 ```sh
-git clone git clone https://github.com/iotaledger/cli-wallet -b develop
+git clone https://github.com/iotaledger/cli-wallet -b develop
 cd cli-wallet
 cargo build --profile production
 ```

--- a/documentation/docs/02_account_manager.md
+++ b/documentation/docs/02_account_manager.md
@@ -18,7 +18,7 @@ The wallet needs to be initialised (`init` command) and with at least one accoun
 #### Example
 
 ```sh
-$ ./wallet
+./wallet
 ```
 
 ### `./wallet [account]`
@@ -30,7 +30,7 @@ The wallet needs to be initialised (`init` command).
 #### Example
 
 ```sh
-$ ./wallet main
+./wallet main
 ```
 
 ### `./wallet backup`
@@ -47,7 +47,7 @@ Creates a stronghold backup file.
 
 Create a stronghold backup file.
 ```sh
-$ ./wallet backup backup.stronghold
+./wallet backup backup.stronghold
 ```
 
 ### `./wallet change-password`
@@ -58,7 +58,7 @@ Changes the stronghold password.
 
 Change the stronghold password.
 ```sh
-$ ./wallet change-password
+./wallet change-password
 ```
 
 ### `./wallet help`
@@ -68,7 +68,7 @@ Displays the account manager interface usage and exits.
 #### Example
 
 ```sh
-$ ./wallet help
+./wallet help
 ```
 
 ### `./wallet init`
@@ -91,24 +91,24 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 Initialise the wallet with a randomly generated mnemonic and the default node.
 ```sh
-$ ./wallet init
+./wallet init
 ```
 
 Initialise the wallet with a given mnemonic and the default node.
 DO NOT USE THIS MNEMONIC.
 ```sh
-$ ./wallet init --mnemonic "aunt middle impose faith ramp kid olive good practice motor grab ready group episode oven matrix silver rhythm avocado assume humble tiger shiver hurt"
+./wallet init --mnemonic "aunt middle impose faith ramp kid olive good practice motor grab ready group episode oven matrix silver rhythm avocado assume humble tiger shiver hurt"
 ```
 
 Initialise the wallet with a randomly generated mnemonic and a given node.
 ```sh
-$ ./wallet init --node http://localhost:14265
+./wallet init --node http://localhost:14265
 ```
 
 Initialise the wallet with a given coin type.
 See [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) for all registered coin types.
 ```sh
-$ ./wallet init --coin-type 4219
+./wallet init --coin-type 4219
 ```
 
 ### `./wallet mnemonic`
@@ -119,7 +119,7 @@ Generates a new random mnemonic.
 
 Generate a new random mnemonic.
 ```sh
-$ ./wallet mnemonic
+./wallet mnemonic
 ```
 
 ### `./wallet new`
@@ -138,12 +138,12 @@ The wallet needs to be initialised (`init` command).
 
 Create a new account with the account index as alias.
 ```sh
-$ ./wallet new
+./wallet new
 ```
 
 Create a new account with a provided alias.
 ```sh
-$ ./wallet new main
+./wallet new main
 ```
 
 ### `./wallet restore`
@@ -160,7 +160,7 @@ Restores accounts from a stronghold backup file.
 
 Restore accounts from a stronghold backup file.
 ```sh
-$ ./wallet restore backup.stronghold
+./wallet restore backup.stronghold
 ```
 
 ### `./wallet set-node`
@@ -178,7 +178,7 @@ The new node URL is persisted to the storage and all future requests will use it
 #### Example
 
 ```sh
-$ ./wallet set-node http://localhost:14265
+./wallet set-node http://localhost:14265
 ```
 
 ### `./wallet sync`
@@ -188,5 +188,5 @@ Synchronises all accounts.
 #### Example
 
 ```sh
-$ ./wallet sync
+./wallet sync
 ```

--- a/documentation/docs/04_step_by_step.md
+++ b/documentation/docs/04_step_by_step.md
@@ -8,14 +8,14 @@ It is advised to do them all at least once in the given order to understand the 
 
 Initialise the wallet with a given node and a randomly generated mnemonic.
 ```sh
-$ ./wallet init --node [NODE API URL]
+./wallet init --node [NODE API URL]
 > ...
 > INFO  Mnemonic stored successfully
 ```
 
 Create a main account.
 ```sh
-$ ./wallet new main
+./wallet new main
 > ...
 > INFO  Created account "main"
 > Account "main": exit
@@ -23,7 +23,7 @@ $ ./wallet new main
 
 Create a savings account.
 ```sh
-$ ./wallet new savings
+./wallet new savings
 > ...
 > INFO  Created account "savings"
 > Account "savings": exit
@@ -33,7 +33,7 @@ $ ./wallet new savings
 
 Get some funds from the faucet to the main account.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": faucet [FAUCET ENQUEUE API URL]
 > ...
 > Account "main": sync
@@ -46,7 +46,7 @@ $ ./wallet main
 
 Get an address from the savings account.
 ```sh
-$ ./wallet savings
+./wallet savings
 > Account "savings": addresses
 > INFO  Address 0: [ADDRESS]
 > Account "savings": exit
@@ -54,7 +54,7 @@ $ ./wallet savings
 
 Send a regular amount from the main account to the savings address.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": send [ADDRESS] 1000000
 > ...
 > INFO  Transaction sent:
@@ -67,7 +67,7 @@ $ ./wallet main
 
 Generate a new address from the savings account.
 ```sh
-$ ./wallet savings
+./wallet savings
 > Account "savings": new-address
 > ...
 > INFO  Address 1: [ADDRESS]
@@ -76,7 +76,7 @@ $ ./wallet savings
 
 Send a micro amount from the main account to the savings address.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": send-micro [ADDRESS] 1
 > ...
 > INFO  Micro transaction sent:
@@ -87,7 +87,7 @@ $ ./wallet main
 
 Check the savings balance.
 ```sh
-$ ./wallet savings
+./wallet savings
 > Account "savings": balance
 > ...
 > INFO  AccountBalance ...
@@ -100,7 +100,7 @@ $ ./wallet savings
 
 Mint native tokens, with foundry metadata, from the main account.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": mint-native-token 1000 1000 --foundry-metadata-hex 0xabcdef
 > ...
 > INFO  Native token minting transaction sent:
@@ -113,7 +113,7 @@ $ ./wallet main
 
 Generate a new address from the savings account.
 ```sh
-$ ./wallet savings
+./wallet savings
 > Account "savings": new-address
 > ...
 > INFO  Address 2: [ADDRESS]
@@ -122,7 +122,7 @@ $ ./wallet savings
 
 Send native tokens to the savings address.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": sync
 > ...
 > INFO  Synced: AccountBalance ...TokenId([TOKEN ID])...
@@ -139,7 +139,7 @@ $ ./wallet main
 
 Mint an NFT.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": mint-nft
 > ...
 > INFO  NFT minting transaction sent:
@@ -152,7 +152,7 @@ $ ./wallet main
 
 Generate a new address from the savings account.
 ```sh
-$ ./wallet savings
+./wallet savings
 > Account "savings": new-address
 > ...
 > INFO  Address 3: [ADDRESS]
@@ -161,7 +161,7 @@ $ ./wallet savings
 
 Send the NFT to the savings address.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": sync
 > ...
 > INFO  Synced: AccountBalance ...NftId([NFT ID])...
@@ -176,7 +176,7 @@ $ ./wallet main
 
 List the transactions of the main account.
 ```sh
-$ ./wallet main
+./wallet main
 > Account "main": transactions
 > ...
 > INFO  Transaction...


### PR DESCRIPTION
# Description of change

I removed the $ from the code blocks so that people can just copy & paste code blocks

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
